### PR TITLE
First pass at Apple Silicon MPS back end

### DIFF
--- a/requirements-silicon.txt
+++ b/requirements-silicon.txt
@@ -1,0 +1,16 @@
+flask
+flask-cloudflared
+flask-cors
+flask-compress
+markdown
+Pillow
+colorama
+torch
+transformers==4.28.1
+webuiapi
+edge-tts
+silero-api-server
+torchvision
+torchaudio
+diffusers
+accelerate


### PR DESCRIPTION
This is a quick hack to get the MPS back end for torch up and running, which adds GPU acceleration for Apple Silicon systems.  I've been using it for about a week (primarily without SD, but SD works if you have enough memory).  A less fussy `requirements-macos.txt` is included for convenience to get it up and running.

MPS doesn't work well float16, so there's a tweak to make cuda the special case rather than the other way around.