### PR TITLE
Added a default StartSTExtras_default.bat

### DIFF
--- a/StartSTExtras_default.bat
+++ b/StartSTExtras_default.bat
@@ -1,0 +1,1 @@
+python server.py --enable-modules=caption,summarize,classify 

--- a/StartSTExtras_default.bat
+++ b/StartSTExtras_default.bat
@@ -1,1 +1,3 @@
 python server.py --enable-modules=caption,summarize,classify 
+
+//if you want to enable other modules, simply make a copy of this file and modify the arguments above. Try to avoid mofidying this file itself, to avoid overwriting it when updating ST Extras in the future. Refer to https://docs.sillytavern.app/extras/installation/#running-extras-after-install for more information.


### PR DESCRIPTION
A .bat startup file for casual users to have a file they can "run" right away, and then modify and edit following the instructions on the documentation page.