### PR TITLE
Feature: Speech-to-text module using Vosk, Whisper from audio file sent by ST.

### DIFF
--- a/modules/speech_recognition/vosk_module.py
+++ b/modules/speech_recognition/vosk_module.py
@@ -1,0 +1,77 @@
+"""
+Speech-to-text module based on Vosk for SillyTavern Extras
+    - Vosk website: https://alphacephei.com/vosk/
+    - Vosk api: https://github.com/alphacep/vosk-api
+
+Authors:
+    - Tony Ribeiro (https://github.com/Tony-sama)
+
+Models are saved into user cache folder, example: C:/Users/toto/.cache/vosk
+
+References:
+    - Code adapted from: https://github.com/alphacep/vosk-api/blob/master/python/example/test_simple.py
+"""
+from flask import jsonify, abort, request
+
+import wave
+from vosk import Model, KaldiRecognizer, SetLogLevel
+import soundfile
+
+DEBUG_PREFIX = "<stt vosk module>"
+RECORDING_FILE_PATH = "stt_test.wav"
+
+model = None
+
+SetLogLevel(-1)
+
+def load_model(file_path=None):
+    """
+    Load given vosk model from file or default to en-us model.
+    Download model to user cache folder, example: C:/Users/toto/.cache/vosk
+    """
+
+    if file_path is None:
+        return Model(lang="en-us")
+    else:
+        return Model(file_path)
+
+def process_audio():
+    """
+    Transcript request audio file to text using Whisper
+    """
+
+    if model is None:
+        print(DEBUG_PREFIX,"Vosk model not initialized yet.")
+        return ""
+
+    try:    
+        file = request.files.get('AudioFile')
+        file.save(RECORDING_FILE_PATH)
+
+        # Read and rewrite the file with soundfile
+        data, samplerate = soundfile.read(RECORDING_FILE_PATH)
+        soundfile.write(RECORDING_FILE_PATH, data, samplerate)
+
+        wf = wave.open(RECORDING_FILE_PATH, "rb")
+        if wf.getnchannels() != 1 or wf.getsampwidth() != 2 or wf.getcomptype() != "NONE":
+            print("Audio file must be WAV format mono PCM.")
+            abort(500, DEBUG_PREFIX+" Audio file must be WAV format mono PCM.")
+
+        rec = KaldiRecognizer(model, wf.getframerate())
+        #rec.SetWords(True)
+        #rec.SetPartialWords(True)
+
+        while True:
+            data = wf.readframes(4000)
+            if len(data) == 0:
+                break
+            if rec.AcceptWaveform(data):
+                break
+        
+        transcript = rec.Result()[14:-3]
+        print(DEBUG_PREFIX, "Transcripted from request audio file:", transcript)
+        return jsonify({"transcript": transcript})
+
+    except Exception as e: # No exception observed during test but we never know
+        print(e)
+        abort(500, DEBUG_PREFIX+" Exception occurs while processing audio")

--- a/modules/speech_recognition/whisper_module.py
+++ b/modules/speech_recognition/whisper_module.py
@@ -1,0 +1,57 @@
+"""
+Speech-to-text module based on Whisper for SillyTavern Extras
+    - Whisper github: https://github.com/openai/whisper
+
+Authors:
+    - Tony Ribeiro (https://github.com/Tony-sama)
+
+Models are saved into user cache folder, example: C:/Users/toto/.cache/whisper
+
+References:
+    - Code adapted from:
+        - whisper github: https://github.com/openai/whisper
+        - oobabooga text-generation-webui github: https://github.com/oobabooga/text-generation-webui
+"""
+from random import sample
+from flask import jsonify, abort, request
+
+import whisper
+
+DEBUG_PREFIX = "<stt whisper module>"
+RECORDING_FILE_PATH = "stt_test.wav"
+
+model = None
+
+def load_model(file_path=None):
+    """
+    Load given vosk model from file or default to en-us model.
+    Download model to user cache folder, example: C:/Users/toto/.cache/vosk
+    """
+
+    if file_path is None:
+        return whisper.load_model("base.en")
+    else:
+        return whisper.load_model(file_path)
+    
+def process_audio():
+    """
+    Transcript request audio file to text using Whisper
+    """
+
+    if model is None:
+        print(DEBUG_PREFIX,"Whisper model not initialized yet.")
+        return ""
+
+    try:    
+        file = request.files.get('AudioFile')
+        file.save(RECORDING_FILE_PATH)
+          
+        result = model.transcribe(RECORDING_FILE_PATH)
+        transcript = result["text"]
+        print(DEBUG_PREFIX, "Transcripted from audio file (whisper):", transcript)
+
+        return jsonify({"transcript": transcript})
+
+    except Exception as e: # No exception observed during test but we never know
+        print(e)
+        abort(500, DEBUG_PREFIX+" Exception occurs while processing audio")

--- a/requirements-complete.txt
+++ b/requirements-complete.txt
@@ -18,3 +18,6 @@ chromadb
 sentence_transformers
 edge-tts
 TTS
+vosk
+sounddevice
+openai-whisper


### PR DESCRIPTION
revision of [PR#84](https://github.com/SillyTavern/SillyTavern-extras/pull/84), too lazy to solve all conflict of rebase so simply inject the new part in neo branch.

This module provide speech-to-text from audio file sent by ST using Vosk or Whisper. Tried to not add too much to server.py, so put the stt module into their own files and used "add_url_rule" to add the api routes.

### Features
- STT providers
    - [Vosk](https://github.com/alphacep/vosk-api): open source STT with a library natively allowing streaming voice in real time
    - [Whisper](https://github.com/openai/whisper): open source STT, better accuracy than Vosk but need speech detection done beforehand. Currently using Vosk to cut voice for Whisper.

### What changed
- Server arguments
   - vosk-stt: activate Vosk module
   - whisper-stt: activate Whisper module
   - stt-vosk-model-path: path to vosk model, if not given it will be downloaded automatically and store in user cache folder.
   - stt-whisper-model-path: same but for whisper model. Default model are the smallest english ones about 100Mb.
- New API routes
   -  /api/speech-recognition/vosk/process-audio: Process the audio file sent in the request using Vosk, need to convert it to proper wav format using soundevice, only firefox send compatible file so far Chrome and Edge send uncompatible files.
   - /api/speech-recognition/whisper/process-audio: Process the audio file sent in the request using Whisper, no need for converting the file, whisper manage firefox/chrome/edge file directly.
- Requirements
   - packages 
       - sounddevice (to convert wav file into proper format for vosk using wave)
       - vosk (for Vosk STT)
       - openai-whisper (for Whisper STT)
   - ffmpeg (suposed to be needed by whisper, not sure if it install via pip or need external one, I do have both)

### Tests
 - Tested only on Windows 11 / firefox 115 / chrome 115 / edge 115
 - the received audio file is stored in a file "stt_test.wav" that can be used to assess audio quality or just checking if recording works.
 - Running whisper can use about 1Gb VRAM.
 - example of command:
     - `python server.py --enable-modules=vosk-stt` 
     - `python server.py --enable-modules=whisper-stt` 
     - `python server.py --enable-modules=vosk-stt --vosk-stt-model-path=modules\stt\vosk-model-en-us-0.22`