### PR TITLE
Update server.py for new chroma

### DIFF
--- a/server.py
+++ b/server.py
@@ -257,7 +257,6 @@ if "chromadb" in modules:
     print("Initializing ChromaDB")
     import chromadb
     import posthog
-    from chromadb.config import Settings
     from sentence_transformers import SentenceTransformer
 
     # Assume that the user wants in-memory unless a host is specified
@@ -265,22 +264,20 @@ if "chromadb" in modules:
     posthog.capture = lambda *args, **kwargs: None
     if args.chroma_host is None:
         if args.chroma_persist:
-            chromadb_client = chromadb.Client(Settings(anonymized_telemetry=False, persist_directory=args.chroma_folder, chroma_db_impl='duckdb+parquet'))
+            chromadb_client = chromadb.PersistentClient(anonymized_telemetry=False, persist_directory=args.chroma_folder, chroma_db_impl='duckdb+parquet')
             print(f"ChromaDB is running in-memory with persistence. Persistence is stored in {args.chroma_folder}. Can be cleared by deleting the folder or purging db.")
         else:
-            chromadb_client = chromadb.Client(Settings(anonymized_telemetry=False))
+            chromadb_client = chromadb.EphemeralClient(anonymized_telemetry=False)
             print(f"ChromaDB is running in-memory without persistence.")
     else:
         chroma_port=(
             args.chroma_port if args.chroma_port else DEFAULT_CHROMA_PORT
         )
-        chromadb_client = chromadb.Client(
-            Settings(
+        chromadb_client = chromadb.HttpClient(
                 anonymized_telemetry=False,
                 chroma_api_impl="rest",
                 chroma_server_host=args.chroma_host,
                 chroma_server_http_port=chroma_port
-            )
         )
         print(f"ChromaDB is remotely configured at {args.chroma_host}:{chroma_port}")
 


### PR DESCRIPTION
Hi, i got this error during docker launch:

I try to [migrate ](https://docs.trychroma.com/migration)but seems it is hard to done. 
So i just upgrade the code and start a new Chroma, at least i can launch the extras server now.

```
llm-sillytavern-extras-1  | Initializing ChromaDB
llm-sillytavern-extras-1  | Traceback (most recent call last):
llm-sillytavern-extras-1  |   File "/sillytavern-extras/server.py", line 268, in <module>
llm-sillytavern-extras-1  |     chromadb_client = chromadb.Client(Settings(anonymized_telemetry=False, persist_directory=args.chroma_folarquet'))
llm-sillytavern-extras-1  |   File "/root/miniconda3/lib/python3.10/site-packages/chromadb/__init__.py", line 107, in Client
llm-sillytavern-extras-1  |     system = System(settings)
llm-sillytavern-extras-1  |   File "/root/miniconda3/lib/python3.10/site-packages/chromadb/config.py", line 175, in __init__
llm-sillytavern-extras-1  |     if settings[key] is not None:
llm-sillytavern-extras-1  |   File "/root/miniconda3/lib/python3.10/site-packages/chromadb/config.py", line 110, in __getitem__
llm-sillytavern-extras-1  |     raise ValueError(LEGACY_ERROR)
llm-sillytavern-extras-1  | ValueError: You are using a deprecated configuration of Chroma.
llm-sillytavern-extras-1  | 
llm-sillytavern-extras-1  | If you do not have data you wish to migrate, you only need to change how you construct
llm-sillytavern-extras-1  | your Chroma client. Please see the "New Clients" section of https://docs.trychroma.com/migration.
llm-sillytavern-extras-1  | ________________________________________________________________________________________________
llm-sillytavern-extras-1  |
llm-sillytavern-extras-1  | If you do have data you wish to migrate, we have a migration tool you can use in order to
llm-sillytavern-extras-1  | migrate your data to the new Chroma architecture.
llm-sillytavern-extras-1  | Please `pip install chroma-migrate` and run `chroma-migrate` to migrate your data and then
llm-sillytavern-extras-1  | change how you construct your Chroma client.
llm-sillytavern-extras-1  |
llm-sillytavern-extras-1  | See https://docs.trychroma.com/migration for more information or join our discord at https://discord.gg/8g5FESbj for help!
llm-sillytavern-extras-1  |
llm-sillytavern-extras-1 exited with code 0
```
After:
![image](https://github.com/SillyTavern/SillyTavern-extras/assets/6138806/d7e0f40a-1c6a-4441-9072-cb6570df59ca)
