### PR TITLE
Make RVC work on numpy 1.24

### DIFF
--- a/modules/voice_conversion/rvc/vc_infer_pipeline.py
+++ b/modules/voice_conversion/rvc/vc_infer_pipeline.py
@@ -115,7 +115,7 @@ class VC(object):
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(int)
         return f0_coarse, f0bak  # 1-0
 
     def vc(


### PR DESCRIPTION
Still have to see why numba wants older numpy. Maybe it needs to be built from git.