### PR TITLE
Coqui TTS extension, added local custom model management

### DIFF
--- a/data/models/coqui/.placeholder
+++ b/data/models/coqui/.placeholder
@@ -1,0 +1,2 @@
+Put RVC models (in .pth format) here.
+.index files (should have the same name as .pth files) are optional but could help improve the processing time.

--- a/data/models/coqui/.placeholder
+++ b/data/models/coqui/.placeholder
@@ -1,2 +1,2 @@
-Put RVC models (in .pth format) here.
-.index files (should have the same name as .pth files) are optional but could help improve the processing time.
+Put Coqui models folders here.
+Must contains both a "model.pth" and "config.json" file.

--- a/data/models/rvc/.placeholder
+++ b/data/models/rvc/.placeholder
@@ -1,2 +1,3 @@
-Put RVC models (in .pth format) here.
-.index files (should have the same name as .pth files) are optional but could help improve the processing time.
+Put RVC models folder here.
+Must have ".pth" file in it
+.index file is optional but could help improve the processing time/quality.

--- a/modules/voice_conversion/rvc_module.py
+++ b/modules/voice_conversion/rvc_module.py
@@ -63,7 +63,7 @@ def rvc_get_models_list():
             else:
                 print(" > WARNING: Missing pth, ignored folder")
 
-        # Return the output_audio_path object as a response
+        # Return the list of valid folders
         response = json.dumps({"models_list":model_list})
         return response
 

--- a/server.py
+++ b/server.py
@@ -392,12 +392,14 @@ if "coqui-tts" in modules:
             if not coqui_module.install_model(i):
                 raise ValueError("Coqui model loading failed, most likely a wrong model name in --coqui-models argument, check log above to see which one")
 
-
+    # Coqui-api models
     app.add_url_rule("/api/text-to-speech/coqui/coqui-api/check-model-state", view_func=coqui_module.coqui_check_model_state, methods=["POST"])
     app.add_url_rule("/api/text-to-speech/coqui/coqui-api/install-model", view_func=coqui_module.coqui_install_model, methods=["POST"])
 
+    # Users models
     app.add_url_rule("/api/text-to-speech/coqui/local/get-models", view_func=coqui_module.coqui_get_local_models, methods=["POST"])
 
+    # Handle both coqui-api/users models
     app.add_url_rule("/api/text-to-speech/coqui/generate-tts", view_func=coqui_module.coqui_generate_tts, methods=["POST"])
 
 def require_module(name):


### PR DESCRIPTION
Constraints:
- Only models without language/speakers options
- User must put their coqui tts model folder into "data/models/coqui".
- Folder must have both "model.pth" and "config.json" file

Updated placeholder files for Coqui and RVC to new storing format.