### PR TITLE
update docker setting

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -13,7 +13,6 @@ DEFAULT_REMOTE_SD_PORT = 7860
 DEFAULT_CHROMA_PORT = 8000
 SILERO_SAMPLES_PATH = "tts_samples"
 SILERO_SAMPLE_TEXT = "The quick brown fox jumps over the lazy dog"
-# ALL_MODULES = ['caption', 'summarize', 'classify', 'keywords', 'prompt', 'sd']
 DEFAULT_SUMMARIZE_PARAMS = {
     "temperature": 1.0,
     "repetition_penalty": 1.0,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN conda create -n extras
 
 RUN /bin/bash -c "source activate extras"
 
-RUN conda install pytorch=2.0.0 torchvision=0.15.0 torchaudio=2.0.0 pytorch-cuda=11.7 git -c pytorch -c nvidia
+RUN conda install pytorch torchvision torchaudio pytorch-cuda=11.7 git -c pytorch -c nvidia -c conda-forge
 
 WORKDIR /sillytavern-extras/
 COPY . .

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,10 +10,10 @@ services:
         REQUIREMENTS: requirements.txt
         MODULES: caption,summarize,classify
 #        REQUIREMENTS: requirements-complete.txt
-#        MODULES: caption,summarize,classify,keywords,prompt,sd,tts,chromadb
+#        MODULES: caption,summarize,classify,sd,silero-tts,edge-tts,chromadb
     ports:
       - "5100:5100"
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
     command: python server.py --enable-modules=caption,summarize,classify
-#    command: python server.py --enable-modules=caption,summarize,classify,keywords,prompt,sd,tts,chromadb
+#    command: python server.py --enable-modules=caption,summarize,classify,sd,silero-tts,edge-tts,chromadb


### PR DESCRIPTION
I got this error when i reinstall my docker and rebuild.
```
=> CACHED [sillytavern-extras  2/11] RUN apt-get update && apt-get install -y --no-install-recommends         python3 python3-venv wget build-essential     
 => CACHED [sillytavern-extras  3/11] RUN wget     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh     && mkdir /root/.conda     && bas
 => CACHED [sillytavern-extras  4/11] RUN conda --version                                                                                                    
 => CACHED [sillytavern-extras  5/11] RUN conda init                                                                                                         
 => CACHED [sillytavern-extras  6/11] RUN conda create -n extras                                                                                             
 => CACHED [sillytavern-extras  7/11] RUN /bin/bash -c "source activate extras"                                                                              
 => ERROR [sillytavern-extras  8/11] RUN conda install pytorch=2.0.0 torchvision=0.15.0 torchaudio=2.0.0 pytorch-cuda=11.7 git -c pytorch -c nvidia -c conda-
------
 > [sillytavern-extras  8/11] RUN conda install pytorch=2.0.0 torchvision=0.15.0 torchaudio=2.0.0 pytorch-cuda=11.7 git -c pytorch -c nvidia -c conda-forge:
0.488 Collecting package metadata (current_repodata.json): ...working... done
20.29 Solving environment: ...working... unsuccessful initial attempt using frozen solve. Retrying with flexible solve.
20.29 Collecting package metadata (repodata.json): ...working... done
113.4 Solving environment: ...working... unsuccessful initial attempt using frozen solve. Retrying with flexible solve.
580.6 Solving environment: ...working...
1184.4 Found conflicts! Looking for incompatible packages.
1184.4 This can take several minutes.  Press CTRL-C to abort.
failed
1212.8
1212.8 UnsatisfiableError: The following specifications were found
1212.8 to be incompatible with the existing python installation in your environment:
1212.8
1212.8 Specifications:
1212.8
1212.8   - torchaudio=2.0.0 -> python[version='>=3.10,<3.11.0a0|>=3.8,<3.9.0a0|>=3.9,<3.10.0a0']
1212.8   - torchvision=0.15.0 -> python[version='>=3.10,<3.11.0a0|>=3.8,<3.9.0a0|>=3.9,<3.10.0a0']
1212.8
1212.8 Your python: python=3.11
1212.8
1212.8 If python is on the left-most side of the chain, that's the version you've asked for.
1212.8 When python appears to the right, that indicates that the thing on the left is somehow
1212.8 not available for the python version you are constrained to. Note that conda will not
1212.8 change your python version to a different minor version unless you explicitly specify
1212.8 that.
1212.8
1212.8 The following specifications were found to be incompatible with each other:
1212.8
1212.8 Output in format: Requested package -> Available versions
1212.8
1212.8 Package pytorch conflicts for:
1212.8 torchaudio=2.0.0 -> pytorch==2.0.0
1212.8 torchvision=0.15.0 -> pytorch==2.0.0
1212.8
1212.8 Package pytorch-cuda conflicts for:
1212.8 torchvision=0.15.0 -> pytorch-cuda[version='11.7.*|11.8.*']
1212.8 torchaudio=2.0.0 -> pytorch==2.0.0 -> pytorch-cuda[version='>=11.7,<11.8|>=11.8,<11.9']
1212.8 pytorch=2.0.0 -> pytorch-cuda[version='>=11.7,<11.8|>=11.8,<11.9']
1212.8 torchvision=0.15.0 -> pytorch==2.0.0 -> pytorch-cuda[version='>=11.7,<11.8|>=11.8,<11.9']
1212.8 torchaudio=2.0.0 -> pytorch-cuda[version='11.7.*|11.8.*']
1212.8
1212.8 Package setuptools conflicts for:
1212.8 python=3.11 -> pip -> setuptools
1212.8 pytorch=2.0.0 -> jinja2 -> setuptools
1212.8
1212.8 Package libxml2 conflicts for:
1212.8 git -> gettext -> libxml2[version='>=2.10.3,<2.11.0a0|>=2.9.10,<2.10.0a0']
1212.8 torchvision=0.15.0 -> ffmpeg[version='>=4.2'] -> libxml2[version='>=2.10.3,<2.11.0a0|>=2.10.4,<2.11.0a0|>=2.11.3,<2.12.0a0|>=2.11.4,<2.12.0a0|>=2.11.52.11.0a0|>=2.9.13,<2.11.0a0|>=2.9.12,<2.11.0a0']
1212.8
1212.8 Package ca-certificates conflicts for:
1212.8 git -> openssl[version='>=3.1.2,<4.0a0'] -> ca-certificates
1212.8 python=3.11 -> openssl[version='>=3.1.2,<4.0a0'] -> ca-certificates
1212.8
1212.8 Package openblas conflicts for:
1212.8 torchaudio=2.0.0 -> numpy[version='>=1.11'] -> openblas[version='0.2.18.*|0.2.18|0.2.18.*|0.2.19|0.2.19.*|0.2.20|0.2.20.*|>=0.2.20,<0.2.21.0a0|>=0.3.3]
1212.8 torchvision=0.15.0 -> numpy[version='>=1.11'] -> openblas[version='0.2.18.*|0.2.18|0.2.18.*|0.2.19|0.2.19.*|0.2.20|0.2.20.*|>=0.2.20,<0.2.21.0a0|>=0.35']
1212.8
1212.8 Package _libgcc_mutex conflicts for:
1212.8 pytorch=2.0.0 -> _openmp_mutex[version='>=4.5'] -> _libgcc_mutex==0.1[build='main|conda_forge']
1212.8 python=3.11 -> libgcc-ng[version='>=12'] -> _libgcc_mutex[version='*|0.1',build='main|main|conda_forge']
1212.8 git -> libgcc-ng[version='>=12'] -> _libgcc_mutex[version='*|0.1',build='main|main|conda_forge']
1212.8
1212.8 Package libffi conflicts for:
1212.8 git -> gettext -> libffi[version='>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.4.2,<3.5.0a0|>=3.2.1,<3.3a0']
1212.8 pytorch=2.0.0 -> python[version='>=3.10,<3.11.0a0'] -> libffi[version='>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.4,<3.5|>=3.4,<4.0a0|>=3.4.2,<3.5.0a0|>=3.2.
1212.8 torchaudio=2.0.0 -> python[version='>=3.8,<3.9.0a0'] -> libffi[version='>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.4,<4.0a0|>=3.4.2,<3.5.0a0|>=3.4,<3.5|>=3.2
1212.8 torchvision=0.15.0 -> python[version='>=3.8,<3.9.0a0'] -> libffi[version='>=3.2.1,<3.3.0a0|>=3.3,<3.4.0a0|>=3.4,<4.0a0|>=3.4.2,<3.5.0a0|>=3.4,<3.5|>=3
1212.8 python=3.11 -> libffi[version='>=3.4,<3.5|>=3.4,<4.0a0|>=3.4.2,<3.5.0a0']
1212.8
1212.8 Package libexpat conflicts for:
1212.8 git -> libexpat[version='>=2.5.0,<3.0a0']
1212.8 git -> expat[version='>=2.5.0,<3.0a0'] -> libexpat==2.5.0=hcb278e6_1The following specifications were found to be incompatible with your system:
1212.8
1212.8   - feature:/linux-64::__glibc==2.31=0
1212.8   - feature:/linux-64::__unix==0=0
1212.8   - feature:|@/linux-64::__glibc==2.31=0
1212.8   - git -> libgcc-ng[version='>=10.3.0'] -> __glibc[version='>=2.17']
1212.8   - python=3.11 -> libgcc-ng[version='>=11.2.0'] -> __glibc[version='>=2.17']
1212.8   - pytorch=2.0.0 -> __glibc[version='>=2.17|>=2.17,<3.0.a0']
1212.8   - pytorch=2.0.0 -> sympy -> __unix
1212.8   - torchaudio=2.0.0 -> pytorch==2.0.0 -> __glibc[version='>=2.17|>=2.17,<3.0.a0']
1212.8   - torchvision=0.15.0 -> pytorch==2.0.0 -> __glibc[version='>=2.17|>=2.17,<3.0.a0']
1212.8
1212.8 Your installed version is: 2.31
1212.8
1212.8
------
failed to solve: process "/bin/sh -c conda install pytorch=2.0.0 torchvision=0.15.0 torchaudio=2.0.0 pytorch-cuda=11.7 git -c pytorch -c nvidia -c conda-forguccessfully: exit code: 1
```

Below is the successful build result after patch (build with requirements-complete.txt):
```
 => [sillytavern-extras internal] load build definition from Dockerfile                                                                                 0.0s 
 => => transferring dockerfile: 960B                                                                                                                    0.0s
 => [sillytavern-extras internal] load .dockerignore                                                                                                    0.0s 
 => => transferring context: 2B                                                                                                                         0.0s 
 => [sillytavern-extras internal] load metadata for docker.io/nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04                                             1.8s 
 => [sillytavern-extras auth] nvidia/cuda:pull token for registry-1.docker.io                                                                           0.0s 
 => [sillytavern-extras  1/11] FROM docker.io/nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04@sha256:1748d07d9cf99bd1af9caac868d7d20bac15ae1b3f9cdc62684  0.0s 
 => [sillytavern-extras internal] load build context                                                                                                    0.1s 
 => => transferring context: 79.82kB                                                                                                                    0.1s 
 => CACHED [sillytavern-extras  2/11] RUN apt-get update && apt-get install -y --no-install-recommends         python3 python3-venv wget build-essenti  0.0s 
 => CACHED [sillytavern-extras  3/11] RUN wget     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh     && mkdir /root/.conda      0.0s 
 => CACHED [sillytavern-extras  4/11] RUN conda --version                                                                                               0.0s 
 => CACHED [sillytavern-extras  5/11] RUN conda init                                                                                                    0.0s 
 => CACHED [sillytavern-extras  6/11] RUN conda create -n extras                                                                                        0.0s 
 => CACHED [sillytavern-extras  7/11] RUN /bin/bash -c "source activate extras"                                                                         0.0s 
 => CACHED [sillytavern-extras  8/11] RUN conda install pytorch torchvision torchaudio pytorch-cuda=11.7 git -c pytorch -c nvidia -c conda-forge        0.0s 
 => CACHED [sillytavern-extras  9/11] WORKDIR /sillytavern-extras/                                                                                      0.0s 
 => [sillytavern-extras 10/11] COPY . .                                                                                                                 0.5s 
 => [sillytavern-extras 11/11] RUN pip install -r requirements-complete.txt                                                                           276.3s 
 => [sillytavern-extras] exporting to image                                                                                                            26.9s 
 => => exporting layers                                                                                                                                26.9s 
 => => writing image sha256:5fa1d7875cacdd68e8efae847ee02d164870aeda6a1673f785d1bec24309794d                                                            0.0s 
 => => naming to docker.io/cohee1207/sillytavern-extras        
```