### PR TITLE
Talkinghead next6

### DIFF
--- a/talkinghead/README.md
+++ b/talkinghead/README.md
@@ -224,9 +224,10 @@ The following postprocessing filters are available. Options for each filter are 
 
 - `analog_lowres`: Simulates a low-resolution analog video signal by blurring the image.
 - `analog_badhsync`: Simulates bad horizontal synchronization (hsync) of an analog video signal, causing a wavy effect that causes the outline of the character to ripple.
+- `analog_distort`: Simulates a rippling, runaway hsync near the top or bottom edge of an image. This can happen with some equipment if the video cable is too long.
 - `analog_vhsglitches`: Simulates a damaged 1980s VHS tape. In each 25 FPS frame, causes random lines to glitch with VHS noise.
 - `analog_vhstracking`: Simulates a 1980s VHS tape with bad tracking. The image floats up and down, and a band of VHS noise appears at the bottom.
-- `shift_distort`: Simulates a glitchy digital video transport as sometimes depicted in sci-fi, with random blocks of lines shifted horizontally.
+- `shift_distort`: A glitchy digital video transport as sometimes depicted in sci-fi, with random blocks of lines suddenly shifted horizontally temporarily.
 
 **Display**:
 

--- a/talkinghead/README.md
+++ b/talkinghead/README.md
@@ -222,12 +222,11 @@ The following postprocessing filters are available. Options for each filter are 
 
 **Transport**:
 
-Currently, we provide some filters that simulate a lo-fi analog video look.
-
 - `analog_lowres`: Simulates a low-resolution analog video signal by blurring the image.
 - `analog_badhsync`: Simulates bad horizontal synchronization (hsync) of an analog video signal, causing a wavy effect that causes the outline of the character to ripple.
 - `analog_vhsglitches`: Simulates a damaged 1980s VHS tape. In each 25 FPS frame, causes random lines to glitch with VHS noise.
 - `analog_vhstracking`: Simulates a 1980s VHS tape with bad tracking. The image floats up and down, and a band of VHS noise appears at the bottom.
+- `shift_distort`: Simulates a glitchy digital video transport as sometimes depicted in sci-fi, with random blocks of lines shifted horizontally.
 
 **Display**:
 
@@ -260,6 +259,15 @@ The bloom works best on a dark background. We use `lumanoise` to add an imperfec
 ```
 
 Note that we could also use the `translucency` filter to make the character translucent, e.g.: `["translucency", {"alpha": 0.7}]`.
+
+Also, for some glitching video transport that shifts random blocks of lines horizontally, we could add these:
+
+```
+["shift_distort", {"strength": 0.05, "name": "shift_right"}],
+["shift_distort", {"strength": -0.05, "name": "shift_left"}],
+```
+
+Having a unique name for each instance is important, because the name acts as a cache key.
 
 #### Postprocessor example: cheap video camera, amber monochrome computer monitor
 

--- a/talkinghead/TODO.md
+++ b/talkinghead/TODO.md
@@ -7,6 +7,8 @@ As of January 2024, preferably to be completed before the next release.
 
 #### Frontend
 
+- See if we can get this working also with local classify now that we have a `set_emotion` API endpoint.
+  - Responsibilities: the client end should set the emotion when it calls classify, instead of relying on the extras server doing it internally when extras classify is called.
 - Figure out why the crop filter doesn't help in positioning the `talkinghead` sprite in *MovingUI* mode.
   - There must be some logic at the frontend side that reserves a square shape for the talkinghead sprite output,
     regardless of the image dimensions or aspect ratio of the actual `result_feed`.

--- a/talkinghead/TODO.md
+++ b/talkinghead/TODO.md
@@ -88,7 +88,14 @@ Not scheduled for now.
 - To save GPU resources, automatically pause animation when the web browser window with SillyTavern is not in focus. Resume when it regains focus.
   - Needs a new API endpoint for pause/resume. Note the current `/api/talkinghead/unload` is actually a pause function (the client pauses, and
     then just hides the live image), but there is currently no resume function (except `/api/talkinghead/load`, which requires sending an image file).
-
+- Lip-sync talking animation to TTS output.
+  - THA3 has morphs for A, I, U, E, O, and the "mouth delta" shape Δ.
+  - This needs either:
+    - Realtime data from client
+      - Exists already! See `SillyTavern/public/scripts/extensions/tts/index.js`, function `playAudioData`. There's lip sync for VRM (VRoid).
+        Still need to investigate how the VRM plugin extracts phonemes from the audio data.
+    - Or if ST-extras generates the TTS output, then at least a start timestamp for the playback of a given TTS output audio file,
+      and a possibility to stop animating if the user stops the audio.
 
 ### Far future
 
@@ -99,10 +106,4 @@ Definitely not scheduled. Ideas for future enhancements.
   - The algorithm should be cartoon-aware, some modern-day equivalent of waifu2x. A GAN such as 4x-AnimeSharp or Remacri would be nice, but too slow.
   - Maybe the scaler should run at the client side to avoid the need to stream 1024x1024 PNGs.
     - What JavaScript anime scalers are there, or which algorithms are simple enough for a small custom implementation?
-- Lip-sync talking animation to TTS output.
-  - THA3 has morphs for A, I, U, E, O, and the "mouth delta" shape Δ.
-  - This needs either:
-    - Realtime data from client
-    - Or if ST-extras generates the TTS output, then at least a start timestamp for the playback of a given TTS output audio file,
-      and a possibility to stop animating if the user stops the audio.
 - Group chats / visual novel mode / several talkingheads running simultaneously.

--- a/talkinghead/TODO.md
+++ b/talkinghead/TODO.md
@@ -63,20 +63,13 @@ Not scheduled for now.
   - The effect on speed will be small; the compute-heaviest part is the inference of the THA3 deep-learning model.
 - Add more postprocessing filters. Possible ideas, no guarantee I'll ever get around to them:
   - Pixelize, posterize (8-bit look)
-  - Analog video glitches
-    - Partition image into bands, move some left/right temporarily (for a few frames now that we can do that)
-    - Another effect of bad VHS hsync: dynamic "bending" effect near top edge:
-      - Distortion by horizontal movement
-      - Topmost row of pixels moves the most, then a smoothly decaying offset profile as a function of height (decaying to zero at maybe 20% of image height, measured from the top)
-      - The maximum offset flutters dynamically in a semi-regular, semi-unpredictable manner (use a superposition of three sine waves at different frequencies, as functions of time)
   - Digital data connection glitches
     - Apply to random rectangles; may need to persist for a few frames to animate and/or make them more noticeable
-    - May need to protect important regions like the character's head (approximately, from the template); we're after "Hollywood glitchy", not actually glitchy
     - Types:
       - Constant-color rectangle
       - Missing data (zero out the alpha?)
       - Blur (leads to replacing by average color, with controllable sigma)
-      - Zigzag deformation
+      - Zigzag deformation (perhaps not needed now that we have `shift_distort`, which is similar, but with a rectangular shape, and applied to full lines of video)
 - Investigate if some particular emotions could use a small random per-frame oscillation applied to "iris_small",
   for that anime "intense emotion" effect (since THA3 doesn't have a morph specifically for the specular reflections in the eyes).
 


### PR DESCRIPTION
Here, have some more postproc filters.

- `shift_distort`: Scifi depiction of a bad digital video transport. Random blocks of lines glitchily shift left and/or right. Usage instructions in README.
- `analog_distort`: Fluttering, runaway hsync near the upper or lower edge of the image. I've seen this caused by an overly long YPbPr component video cable between some equipment.

I originally thought I wasn't going to touch the ST-extras backend for a while until I have the docs ready, but if I'll be experimenting with adding an embeddings provider for RAG next, might as well send these `talkinghead` postproc filters first.

I'll return to finishing up `talkinghead` once I'm done with the RAG interlude.