### PR TITLE
Update script.py -- fixing UnicodeEncodeError: 'charmap' codec can't …

### DIFF
--- a/modules/websearch/script.py
+++ b/modules/websearch/script.py
@@ -8,7 +8,9 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from modules.utils import is_colab
 import atexit
+import sys
 
+sys.stdout.reconfigure(encoding='utf-8')
 
 def get_driver():
     try:


### PR DESCRIPTION
Sometimes in non-English locales the websearch script throws an UnicodeEncodeError exception because print("Found: " + text, links) can't render characters in a system encoding.

For example:
UnicodeEncodeError: 'charmap' codec can't encode character '\u2212' in position 1433: character maps to <undefined>

This small fix sets encoding of print output to UTF-8, sort of resolving the issue.