### PR TITLE
gitignores the cache directory that gets created as a volume for the docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ api_key.txt
 .vscode
 stt_test.wav
 talkinghead/tha3/models
+docker/cache


### PR DESCRIPTION
This cache directory not beeing ignored causes a huge ammount of unstaged files to pop up in your repo when you build your docker so ignoring it might be best.