### PR TITLE
Fixes Docker Volume

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,8 +38,8 @@ services:
 #     ChromaDB - Utilized by ChromaDB.
 #     - "./chromadb:/chromadb"
 #
-#     Real-time Voice CLoning 
-#     - "./models/rvc:/data/models/rvc"
+#     Real-time Voice Cloning
+#     - "./models/rvc:/sillytavern-extras/data/models/rvc"
 #     
     ports:
       - "5100:5100"


### PR DESCRIPTION
The volume inside the docker was bound to the wrong path originally onto 
/data/models/rvc instead of /sillytaver-extras/data/models/rvc.